### PR TITLE
Initial fork and update from conda-forge.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,11 +1,27 @@
-mkdir build
-cd build
+:: cmd
 
-cmake ^
-	-G "NMake Makefiles" ^
-	-DCLI11_BUILD_TESTS=OFF ^
-	-DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-	-DCLI11_BUILD_EXAMPLES=OFF ^
-	%SRC_DIR%
+:: Isolate the build.
+mkdir Build
+cd Build
+if errorlevel 1 exit 1
 
-nmake install
+:: Generate the build files.
+cmake .. -G"Ninja" %CMAKE_ARGS% ^
+      -DCLI11_BUILD_TESTS=ON ^
+      -DCLI11_BUILD_EXAMPLES=OFF ^
+      -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -DCMAKE_BUILD_TYPE=Release
+
+
+:: Build and install.
+ninja install
+if errorlevel 1 exit 1
+
+
+:: Perform tests.
+ninja test
+if errorlevel 1 exit 1
+
+:: Error free exit .
+exit 0

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,12 +1,20 @@
-mkdir build
-cd build
+#!/bin/bash
 
-cmake \
-    -DCMAKE_INSTALL_PREFIX=$PREFIX \
-    -DCLI11_BUILD_TESTS=OFF \
-    -DCLI11_BUILD_EXAMPLES=OFF \
-    -DCMAKE_INSTALL_LIBDIR=lib \
-    ${CMAKE_ARGS} \
-    $SRC_DIR
+# Isolate the build.
+mkdir -p Build
+cd Build || exit 1
 
-make install
+# Generate the build files.
+cmake .. -G"Ninja" ${CMAKE_ARGS} \
+      -DCLI11_BUILD_TESTS=ON \
+      -DCLI11_BUILD_EXAMPLES=OFF \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_BUILD_TYPE=Release
+
+# Build and install.
+ninja install || exit 1
+
+
+# Perform tests.
+ninja test || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,8 @@
 {% set name = "cli11" %}
 {% set version = "2.1.2" %}
+{% set sha_hash = "26291377e892ba0e5b4972cdfd4a2ab3bf53af8dac1f4ea8fe0d1376b625c8cb" %}
+{% set build_number = "0" %}
+
 
 package:
   name: {{ name|lower }}
@@ -7,20 +10,24 @@ package:
 
 source:
   url: https://github.com/CLIUtils/CLI11/archive/v{{ version }}.tar.gz
-  sha256: 26291377e892ba0e5b4972cdfd4a2ab3bf53af8dac1f4ea8fe0d1376b625c8cb
+  sha256: {{ sha_hash }}
 
 build:
-  number: 0
+  number: {{ build_number }}
 
 requirements:
   build:
-    - cmake
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - make  # [unix]
+    - cmake
+    - ninja
+  host:
+    - libboost >=1.61
 
 test:
+  # NOTE: Author's tests are run from the build scripts in all architectures.
   commands:
+    # Insure files are installed to the correct location.
     - test -f $PREFIX/include/CLI/CLI.hpp  # [unix]
     - if exist %LIBRARY_INC%\CLI\CLI.hpp (exit 0) else (exit 1)  # [win]
 
@@ -44,8 +51,9 @@ about:
     Releases for details for current and past releases. Also see the
     Version 1.0 post, Version 1.3 post, or Version 1.6 post for more
     information.
-  doc_url: https://cliutils.github.io/CLI11/book
   dev_url: https://github.com/CLIUtils/CLI11
+  doc_url: https://cliutils.github.io/CLI11/book
+  doc_src_url: https://github.com/CLIUtils/CLI11/tree/main/docs
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
# Changes

Changes:
- Initial fork from conda-forge.
- Update build files:
  - Prefer ninja to NMake/make.
  - Enable author's testing.

# Review Information

## Source

https://github.com/CLIUtils/CLI11

## Upstream Changes

Initial fork, no version change.

## Issues

https://github.com/CLIUtils/CLI11/issues

Nothing that looks like it should stop inclusion.


## Pins and Requireds

Build time testing requires libboost > 1.61 in host file, otherwise this is a header only library.

## Testing

CLI11 tests are exercised as part of the build process. Additional tests help ensure the package is built.


# Closing Comments

This package is required for libmambapy. I can think of no reason not to accept it.

